### PR TITLE
Fix a flaky test

### DIFF
--- a/php-frontend/src/test/java/org/sonar/php/metrics/ExecutableLineVisitorTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/metrics/ExecutableLineVisitorTest.java
@@ -40,7 +40,7 @@ public class ExecutableLineVisitorTest extends ParsingTestUtils {
     String filename = "metrics/executable_lines.php";
     PhpFile file = FileTestUtils.getFile(new File("src/test/resources/"+filename));
     Set<Integer> executableLines = new ExecutableLineVisitor(parse(filename)).getExecutableLines();
-    assertThat(executableLines).containsExactlyElementsOf(expectedExecutableLines(file));
+    assertThat(executableLines).containsOnlyElementsOf(expectedExecutableLines(file));
   }
 
   // returns lines marked with "// +1" comment


### PR DESCRIPTION
The test **org.sonar.php.metrics.ExecutableLineVisitorTest#test** can fail due to a different iteration order of a HashSet. The failure is presented as follows:

**java.lang.AssertionError:
Actual and expected have the same elements but not in the same order, at index 0 actual element was:
<23>
whereas expected element was:
<30>**

The reason is that HashSet makes no guarantee about the iteration order. The specification about HashSet says that "It makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time".

One way to fix this problem is to change HashSet into LinkedHashSet, but here we make another change that is smaller but has the same effect: change **containsExactlyElementsOf** into **containsOnlyElementsOf**.

In [API Documentation](https://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/AbstractIterableAssert.html#containsExactlyElementsOf(java.lang.Iterable)): **containsExactlyElementsOf** says that "verifies that actual contains exactly the elements of the given iterable and nothing else in the same order"; **containsOnlyElementsOf** says that "verifies that actual contains all the elements of the given iterable and nothing else, in any order and ignoring duplicates". Use **containsOnlyElementsOf** instead of **containsExactlyElementsOf** so that we can get rid of the non-deterministic behavior and make the test more stable.
